### PR TITLE
mdadm details parser for influx

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,7 +28,9 @@ def main(args) -> None:
     elif args.use == "ssacli":
         from ssacli import get_disk_errors
     elif args.use == "mdadm":
-        from mdadm import get_disk_errors
+        from mdadm import get_disk_errors, influxdb_print_mdadm_detail
+
+        influxdb_print_mdadm_detail()
     else:
         raise ValueError("Unexpected use value: {}".format(args.use))
 

--- a/main.py
+++ b/main.py
@@ -30,7 +30,8 @@ def main(args) -> None:
     elif args.use == "mdadm":
         from mdadm import get_disk_errors, influxdb_print_mdadm_detail
 
-        influxdb_print_mdadm_detail()
+        if args.details:
+            influxdb_print_mdadm_detail()
     else:
         raise ValueError("Unexpected use value: {}".format(args.use))
 
@@ -46,6 +47,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--use", choices=["megacli", "storcli", "ssacli", "mdadm"], required=True
     )
+    parser.add_argument("--details", type=bool, default=True)
 
     args = parser.parse_args()
 


### PR DESCRIPTION
the original mdadm get errors does not show clear detail. made an new plugin that provides the output of mdadm -D /dev/md0.

this way we can quickly see if the array is in a degraded state

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/orcamobility/raid-telegraf/3)
<!-- Reviewable:end -->
