### PR TITLE
quit silently if no array found. reduce spam in logs for non-raid sys…

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,8 +28,14 @@ def main(args) -> None:
     elif args.use == "ssacli":
         from ssacli import get_disk_errors
     elif args.use == "mdadm":
-        from mdadm import get_disk_errors, influxdb_print_mdadm_detail
+        from mdadm import (
+            get_disk_errors,
+            influxdb_print_mdadm_detail,
+            raid_array_exists,
+        )
 
+        if not raid_array_exists():
+            return
         if args.details:
             influxdb_print_mdadm_detail()
         if args.get_errors:
@@ -53,7 +59,6 @@ if __name__ == "__main__":
     )
     parser.add_argument("--details", type=bool, default=True)
     parser.add_argument("--get-errors", type=bool, default=True)
-
 
     args = parser.parse_args()
 

--- a/mdadm.py
+++ b/mdadm.py
@@ -1,6 +1,6 @@
 # Uses /proc/mdstat and smartctl to get disk errors
-import subprocess as sp
 import re
+import subprocess as sp
 from typing import Dict, Tuple
 
 MD_REGEX = re.compile(r"^(md.+?) :")
@@ -139,6 +139,13 @@ class MdadmBase:
 
 
 mdadm = MdadmBase()
+
+
+def raid_array_exists() -> bool:
+    result = sp.run(["mdadm", "--detail", "--scan"], capture_output=True, text=True)
+    if result.returncode == 0 and "/dev/md" in result.stdout:
+        return True
+    return False
 
 
 def get_disk_errors() -> dict:


### PR DESCRIPTION
on non-raid nvrs, we get spammed in telegraf.log that there is no mdadm devices. 

this will exit silently.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/orcamobility/raid-telegraf/4)
<!-- Reviewable:end -->
